### PR TITLE
Add classifier for Wagtail 4

### DIFF
--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -121,6 +121,8 @@ sorted_classifiers: List[str] = [
     "Framework :: Django CMS :: 3.8",
     "Framework :: Django CMS :: 3.9",
     "Framework :: Django CMS :: 3.10",
+    "Framework :: Django CMS :: 3.11",
+    "Framework :: Django CMS :: 4.0",
     "Framework :: FastAPI",
     "Framework :: Flake8",
     "Framework :: Flask",

--- a/src/trove_classifiers/__init__.py
+++ b/src/trove_classifiers/__init__.py
@@ -195,6 +195,7 @@ sorted_classifiers: List[str] = [
     "Framework :: Wagtail :: 1",
     "Framework :: Wagtail :: 2",
     "Framework :: Wagtail :: 3",
+    "Framework :: Wagtail :: 4",
     "Framework :: ZODB",
     "Framework :: Zope",
     "Framework :: Zope2",


### PR DESCRIPTION
Request to add a new Trove classifier.

## The name of the classifier(s) you would like to add:

* `Framework :: Wagtail :: 4`

## Why do you want to add this classifier?
Wagtail 4.0 RC2 was [released today](https://github.com/wagtail/wagtail/releases/tag/v4.0rc2) - per-version classifiers are useful for Wagtail site developers to easily locate compatible third-party packages.